### PR TITLE
Fix chashsubset balancer with alternative backend

### DIFF
--- a/rootfs/etc/nginx/lua/balancer/chashsubset.lua
+++ b/rootfs/etc/nginx/lua/balancer/chashsubset.lua
@@ -61,7 +61,9 @@ function _M.new(self, backend)
     instance = resty_chash:new(subset_map),
     hash_by = complex_val,
     subsets = subsets,
-    current_endpoints = backend.endpoints
+    current_endpoints = backend.endpoints,
+    traffic_shaping_policy = backend.trafficShapingPolicy,
+    alternative_backends = backend.alternativeBackends,
   }
   setmetatable(o, self)
   self.__index = self

--- a/rootfs/etc/nginx/lua/test/balancer/chashsubset_test.lua
+++ b/rootfs/etc/nginx/lua/test/balancer/chashsubset_test.lua
@@ -86,5 +86,21 @@ describe("Balancer chash subset", function()
         assert.are.equal(#endpoints, 3)
       end
     end)
+
+    it("set alternative backends", function()
+      local backend = get_test_backend(7)
+      backend.trafficShapingPolicy  = {
+        weight = 0,
+        header = "",
+        headerValue = "",
+        cookie = ""
+      }
+      backend.alternativeBackends = {
+        "my-dummy-canary-backend"
+      }
+      local instance = balancer_chashsubset:new(backend)
+      assert.not_equal(instance.traffic_shaping_policy, nil)
+      assert.not_equal(instance.alternative_backends, nil)
+    end)
   end)
 end)


### PR DESCRIPTION
## Summary
chashsubset is ignoring traffic shaping policy and alternative backends. This PR fixes this issue by assigning traffic shaping policy and alternative backends to chashsubset backend.

## What this PR does / why we need it:
Alternative backend and traffic shaping policy works on chash backend. But not chashsubset backend. 

For example, when we configure `nginx.ingress.kubernetes.io/upstream-hash-by-subset` on ingress. Our canary ingress stop receiving traffic.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
* Deploy one main service and one canary service (Yaml files used for testing are attached below)
  * Set canary ingress annotation with `nginx.ingress.kubernetes.io/canary-by-header: X-CANARY`
* Make http calls to service make sure calls are routed to main service
* Make http calls with header `X-CANARY: always` make sure calls are routed to canary service
* Same test can be performed using weight traffic shaping policy

<details>
<summary><h3>Main Service Yaml</h3></summary>
<p>

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mirror-echo-server
  namespace: sre
spec:
  replicas: 5
  selector:
    matchLabels:
      name: mirror-echo-server
  template:
    metadata:
      labels:
        name: mirror-echo-server
    spec:
      containers:
      - name: mirror-echo-server
        image: mendhak/http-https-echo:latest
        ports:
        - containerPort: 80
        env:
        - name: LOG_WITHOUT_NEWLINE
          value: "true"
---
apiVersion: v1
kind: Service
metadata:
  name: mirror-echo-server
  namespace: sre
spec:
  ports:
    - port: 8080
      targetPort: 80
      protocol: TCP
      name: http
  selector:
    name: mirror-echo-server
---
kind: Ingress
apiVersion: networking.k8s.io/v1
metadata:
  annotations:
    nginx.ingress.kubernetes.io/upstream-hash-by: "$arg_hash"
    nginx.ingress.kubernetes.io/upstream-hash-by-subset: "true"
    nginx.ingress.kubernetes.io/upstream-hash-by-subset-size: "3"
  name: echo-ingress-internal
  namespace: sre
spec:
  rules:
  - host: echo.k8s.local
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: mirror-echo-server
            port:
              number: 8080
```
</p>
</details>  


<details>
<summary><h3>Canary Service Yaml</h3></summary>
<p>

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mirror-echo-server-canary
spec:
  replicas: 2
  selector:
    matchLabels:
      name: mirror-echo-server-canary
  template:
    metadata:
      labels:
        name: mirror-echo-server-canary
    spec:
      containers:
      - name: mirror-echo-server-canary
        image: mendhak/http-https-echo:latest
        ports:
        - containerPort: 80
        env:
        - name: LOG_WITHOUT_NEWLINE
          value: "true"
---
apiVersion: v1
kind: Service
metadata:
  name: mirror-echo-server-canary
spec:
  ports:
    - port: 8080
      targetPort: 80
      protocol: TCP
      name: http
  selector:
    name: mirror-echo-server-canary
---
kind: Ingress
apiVersion: networking.k8s.io/v1
metadata:
  annotations:
    nginx.ingress.kubernetes.io/upstream-hash-by: "$arg_hash"
    nginx.ingress.kubernetes.io/upstream-hash-by-subset: "true"
    nginx.ingress.kubernetes.io/upstream-hash-by-subset-size: "1"
    nginx.ingress.kubernetes.io/canary: "true"
    nginx.ingress.kubernetes.io/canary-weight: "0"
    nginx.ingress.kubernetes.io/canary-by-header: "X-CANARY"
  name: echo-canary-ingress-internal
spec:
  rules:
  - host: echo.k8s.local
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: mirror-echo-server-canary
            port:
              number: 8080
```
</p>
</details>  


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
